### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/323/71/85632371.geojson
+++ b/data/856/323/71/85632371.geojson
@@ -661,6 +661,10 @@
     },
     "wof:country":"PM",
     "wof:country_alpha3":"SPM",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"7679695dd1e959a38eec0fe72784305a",
     "wof:hierarchy":[
         {
@@ -676,7 +680,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1537303773,
+    "wof:lastmodified":1582358125,
     "wof:name":"Saint Pierre and Miquelon",
     "wof:parent_id":136253037,
     "wof:placetype":"country",

--- a/data/890/435/983/890435983.geojson
+++ b/data/890/435/983/890435983.geojson
@@ -368,6 +368,9 @@
     },
     "wof:country":"PM",
     "wof:created":1469052089,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1298c8adcdea38a2303919d8a9977525",
     "wof:hierarchy":[
         {
@@ -381,7 +384,7 @@
         }
     ],
     "wof:id":890435983,
-    "wof:lastmodified":1566600168,
+    "wof:lastmodified":1582358126,
     "wof:name":"Saint-Pierre",
     "wof:parent_id":85677293,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.