### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/115/884/660/1/1158846601.geojson
+++ b/data/115/884/660/1/1158846601.geojson
@@ -48,6 +48,9 @@
     "name:ang_x_preferred":[
         "Halga Petrus and Miquelon"
     ],
+    "name:anp_x_preferred":[
+        "\u0938\u0947\u0902\u091f \u092a\u093f\u092f\u0947\u0930 \u0906\u0930\u094b \u092e\u093f\u0915\u0947\u0932\u094b"
+    ],
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646 \u0628\u064a\u064a\u0631 \u0648\u0645\u064a\u0643\u0644\u0648\u0646"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:arg_x_preferred":[
         "Saint-Pierre y Miquelon"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u0628\u064a\u064a\u0631 \u0648\u0645\u064a\u0643\u0644\u0648\u0646"
     ],
     "name:ast_x_preferred":[
         "Saint Pierre y Miquelon"
@@ -119,10 +125,14 @@
         "Saint-Pierre a Miquelon"
     ],
     "name:ces_x_variant":[
-        "Svat\u00fd Pierre a Miquelon"
+        "Svat\u00fd Pierre a Miquelon",
+        "Saint Pierre a Miquelon"
     ],
     "name:cor_x_preferred":[
         "Sen Peder ha Miquelon"
+    ],
+    "name:cos_x_preferred":[
+        "Saint-Pierre \u00e8 Miquelon"
     ],
     "name:cym_x_preferred":[
         "Saint-Pierre-et-Miquelon"
@@ -212,6 +222,9 @@
     "name:gag_x_preferred":[
         "Sent Pierre hem Miquelon"
     ],
+    "name:gcr_x_preferred":[
+        "Sen Pierre k\u00e9 Miquelon"
+    ],
     "name:gle_x_preferred":[
         "Saint-Pierre-et-Miquelon"
     ],
@@ -220,6 +233,9 @@
     ],
     "name:glg_x_preferred":[
         "San Pedro e Miguel\u00f3n"
+    ],
+    "name:glg_x_variant":[
+        "Saint Pierre et Miquelon"
     ],
     "name:gsw_x_preferred":[
         "Saint-Pierre und Miquelon"
@@ -243,7 +259,8 @@
         "\u05e1\u05df \u05e4\u05d9\u05d9\u05e8 \u05d5\u05de\u05d9\u05e7\u05dc\u05d5\u05df"
     ],
     "name:heb_x_variant":[
-        "\u05e1\u05e0\u05d8 \u05e4\u05d9\u05d9\u05e8 \u05d5\u05de\u05d9\u05e7\u05dc\u05d5\u05df"
+        "\u05e1\u05e0\u05d8 \u05e4\u05d9\u05d9\u05e8 \u05d5\u05de\u05d9\u05e7\u05dc\u05d5\u05df",
+        "\u05e1\u05df-\u05e4\u05d9\u05d9\u05e8 \u05d5\u05de\u05d9\u05e7\u05dc\u05d5\u05df"
     ],
     "name:hin_x_preferred":[
         "\u0938\u093e\u0901-\u092a\u094d\u092f\u0947\u0930 \u0914\u0930 \u092e\u0940\u0915\u0947\u0932\u094b\u0902"
@@ -288,6 +305,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30d4\u30a8\u30fc\u30eb\u5cf6\u30fb\u30df\u30af\u30ed\u30f3\u5cf6"
     ],
+    "name:kaa_x_preferred":[
+        "Sen-Per ha'm Mikelon"
+    ],
     "name:kal_x_preferred":[
         "Saint Pierre aamma Miquelon"
     ],
@@ -308,6 +328,9 @@
     ],
     "name:kin_x_preferred":[
         "Mutagatifu Petero na Mikeloni"
+    ],
+    "name:kir_x_preferred":[
+        "\u0421\u0435\u043d\u043f\u044c\u0435\u0440 \u0436\u0430\u043d\u0430 \u041c\u0438\u043a\u0435\u043b\u043e\u043d"
     ],
     "name:kor_x_preferred":[
         "\uc0dd\ud53c\uc5d0\ub974 \ubbf8\ud074\ub871"
@@ -367,6 +390,9 @@
     ],
     "name:mar_x_variant":[
         "\u0938\u0947\u0902\u091f \u092a\u093f\u092f\u0930\u0947 \u0906\u0923\u093f \u092e\u093f\u0915\u094d\u0935\u0947\u0932\u094b\u0928"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0421\u044d\u043d-\u041f\u044c\u0435\u0440 \u0434\u0438 \u041c\u0438\u043a\u044d\u043b\u043e\u043d"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u0432\u0435\u0442\u0438 \u041f\u0458\u0435\u0440 \u0438 \u041c\u0438\u043a\u0435\u043b\u043e\u043d"
@@ -473,6 +499,9 @@
     "name:sco_x_preferred":[
         "Saunt Pierre an Miquelon"
     ],
+    "name:shn_x_preferred":[
+        "\u101e\u1035\u1004\u103a\u1089\u1015\u102e\u1038\u101a\u1083\u1038 \u101c\u1084\u1088 \u1019\u102d\u1075\u103a\u1088\u1075\u103d\u1086\u1087\u101c\u103d\u107c\u103a\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc3\u0dcf\u0db1\u0dca\u0dad \u0db4\u0dd2\u0dba\u0dbb\u0dda \u0dc4\u0dcf \u0db8\u0dba\u0dd2\u0d9a\u0dca\u0dc0\u0dbd\u0ddc\u0db1\u0dca"
     ],
@@ -482,11 +511,17 @@
     "name:slv_x_preferred":[
         "Saint Pierre in Miquelon"
     ],
+    "name:slv_x_variant":[
+        "Sveti Peter in Mihael"
+    ],
     "name:sme_x_preferred":[
         "Saint Pierre ja Miquelon"
     ],
     "name:sna_x_preferred":[
         "Saint Pierre and Miquelon"
+    ],
+    "name:sna_x_variant":[
+        "Musande Petro ne Mikeroni"
     ],
     "name:som_x_preferred":[
         "Saint Pierre and Miquelon"
@@ -496,6 +531,9 @@
     ],
     "name:sqi_x_preferred":[
         "Sh\u00ebn Pierre dhe Miquelon"
+    ],
+    "name:srd_x_preferred":[
+        "Saint-Pierre e Miquelon"
     ],
     "name:srp_x_preferred":[
         "\u0421\u0435\u043d \u041f\u0458\u0435\u0440 \u0438 \u041c\u0438\u043a\u0435\u043b\u043e\u043d"
@@ -572,6 +610,9 @@
     "name:uzb_x_preferred":[
         "Sen-Pyer va Mikelon"
     ],
+    "name:vec_x_preferred":[
+        "Saint-Pierre e Miquelon"
+    ],
     "name:vie_x_preferred":[
         "Saint-Pierre v\u00e0 Miquelon"
     ],
@@ -583,6 +624,9 @@
     ],
     "name:wol_x_preferred":[
         "Saint Pierre ak Miquelon"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10e1\u10d4\u10dc-\u10de\u10d8\u10d4\u10e0\u10d8 \u10d3\u10dd \u10db\u10d8\u10d9\u10d4\u10da\u10dd\u10dc\u10d8"
     ],
     "name:yor_x_preferred":[
         "Saint Pierre \u00e0ti M\u00eck\u1eb9\u0301l\u1ecd\u0300n"
@@ -809,7 +853,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636576704,
+    "wof:lastmodified":1690855722,
     "wof:name":"Saint Pierre and Miquelon",
     "wof:parent_id":136253037,
     "wof:placetype":"dependency",

--- a/data/856/772/97/85677297.geojson
+++ b/data/856/772/97/85677297.geojson
@@ -65,6 +65,9 @@
     "name:deu_x_preferred":[
         "Miquelon-Langlade"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b9\u03ba\u03b5\u03bb\u03cc\u03bd-\u039b\u03b1\u03bd\u03b3\u03ba\u03bb\u03ac\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Miquelon-Langlade"
     ],
@@ -166,6 +169,9 @@
     ],
     "name:min_x_preferred":[
         "Miquelon-Langlade"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041c\u0438\u043a\u0435\u043b\u043e\u043d-\u041b\u0430\u043d\u0433\u043b\u0430\u0434"
     ],
     "name:mlg_x_preferred":[
         "Miquelon-Langlade"
@@ -289,6 +295,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bc6\u514b\u9686\uff0d\u6717\u683c\u62c9\u5fb7\u5cf6"
+    ],
+    "name:zho_x_variant":[
+        "\u5bc6\u514b\u9686-\u6717\u683c\u62c9\u5fb7"
     ],
     "name:zul_x_preferred":[
         "Miquelon-Langlade"
@@ -414,7 +423,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636502622,
+    "wof:lastmodified":1690855721,
     "wof:name":"Miquelon-Langlade",
     "wof:parent_id":1158846601,
     "wof:placetype":"region",

--- a/data/890/435/983/890435983.geojson
+++ b/data/890/435/983/890435983.geojson
@@ -22,6 +22,9 @@
     "name:afr_x_preferred":[
         "Saint-Pierre"
     ],
+    "name:ara_x_preferred":[
+        "\u0633\u0627\u0646 \u0628\u064a\u064a\u0631"
+    ],
     "name:arg_x_preferred":[
         "Saint-Pierre"
     ],
@@ -39,6 +42,12 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0435\u043d-\u041f'\u0435\u0440"
+    ],
+    "name:bel_x_variant":[
+        "\u0421\u0435\u043d-\u041f\u2019\u0435\u0440"
+    ],
+    "name:ben_x_preferred":[
+        "\u09b8\u09be\u0981-\u09aa\u09bf\u09af\u09bc\u09c7\u09b0"
     ],
     "name:bos_x_preferred":[
         "Saint-Pierre"
@@ -137,6 +146,9 @@
     "name:hun_x_preferred":[
         "Saint-Pierre"
     ],
+    "name:hye_x_preferred":[
+        "\u054d\u0565\u0576 \u054a\u056b\u0565\u057c"
+    ],
     "name:ido_x_preferred":[
         "St Pierre"
     ],
@@ -150,6 +162,9 @@
         "Saint-Pierre"
     ],
     "name:ind_x_preferred":[
+        "Saint-Pierre"
+    ],
+    "name:isl_x_preferred":[
         "Saint-Pierre"
     ],
     "name:ita_x_preferred":[
@@ -176,6 +191,9 @@
     "name:kor_x_preferred":[
         "\uc0dd\ud53c\uc5d0\ub974"
     ],
+    "name:lat_x_preferred":[
+        "Sanctus Petrus"
+    ],
     "name:lav_x_preferred":[
         "Saint-Pierre"
     ],
@@ -193,6 +211,9 @@
     ],
     "name:min_x_preferred":[
         "Saint-Pierre"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0432\u0435\u0442\u0438 \u041f\u0458\u0435\u0440"
     ],
     "name:mlg_x_preferred":[
         "Saint-Pierre"
@@ -278,6 +299,9 @@
     "name:slk_x_preferred":[
         "Saint-Pierre"
     ],
+    "name:sna_x_preferred":[
+        "Musande Petro"
+    ],
     "name:spa_x_preferred":[
         "Saint-Pierre"
     ],
@@ -338,6 +362,9 @@
     "name:wol_x_preferred":[
         "Saint-Pierre"
     ],
+    "name:wuu_x_preferred":[
+        "\u5723\u76ae\u57c3\u5c14"
+    ],
     "name:yor_x_preferred":[
         "Saint-Pierre"
     ],
@@ -358,10 +385,10 @@
     "src:population":"geonames",
     "wd:wordcount":1827,
     "wof:belongsto":[
-        102191575,
         1158846601,
+        85677293,
         136253037,
-        85677293
+        102191575
     ],
     "wof:breaches":[],
     "wof:capital_of":[
@@ -395,7 +422,7 @@
         }
     ],
     "wof:id":890435983,
-    "wof:lastmodified":1636583224,
+    "wof:lastmodified":1690855721,
     "wof:name":"Saint-Pierre",
     "wof:parent_id":85677293,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.