### PR TITLE
pm concordances, placetype local, and more

### DIFF
--- a/data/115/884/660/1/1158846601.geojson
+++ b/data/115/884/660/1/1158846601.geojson
@@ -826,6 +826,7 @@
         "gp:id":23424939,
         "hasc:id":"PM",
         "ioc:id":"SPM",
+        "iso:code":"PM",
         "itu:id":"SPM",
         "loc:id":"n83017162",
         "marc:id":"xl",
@@ -837,6 +838,7 @@
         "wd:id":"Q34617",
         "wmo:id":"FP"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"
@@ -858,7 +860,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639813,
+    "wof:lastmodified":1695881384,
     "wof:name":"Saint Pierre and Miquelon",
     "wof:parent_id":136253037,
     "wof:placetype":"dependency",

--- a/data/856/772/93/85677293.geojson
+++ b/data/856/772/93/85677293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003532,
-    "geom:area_square_m":29909200.14859,
+    "geom:area_square_m":29908909.224027,
     "geom:bbox":"-56.240305,46.752753,-56.144765,46.811591",
     "geom:latitude":46.779881,
     "geom:longitude":-56.189609,
@@ -219,9 +219,9 @@
     "statoids:type":"commune",
     "wd:wordcount":1827,
     "wof:belongsto":[
-        102191575,
         1158846601,
-        136253037
+        136253037,
+        102191575
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -231,8 +231,9 @@
         "hasc:id":"PM.SP",
         "qs_pg:id":219959
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PM",
-    "wof:geomhash":"098f2edbd695cb79134bfef16283af8b",
+    "wof:geomhash":"e43296247fa19bdcc02f68639d66e4f8",
     "wof:hierarchy":[
         {
             "continent":102191575,
@@ -250,7 +251,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636576695,
+    "wof:lastmodified":1695884975,
     "wof:name":"Saint-Pierre",
     "wof:parent_id":1158846601,
     "wof:placetype":"region",

--- a/data/856/772/97/85677297.geojson
+++ b/data/856/772/97/85677297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025142,
-    "geom:area_square_m":212221272.22863,
+    "geom:area_square_m":212221618.055971,
     "geom:bbox":"-56.396596,46.780748,-56.235504,47.141262",
     "geom:latitude":46.951612,
     "geom:longitude":-56.32442,
@@ -391,8 +391,7 @@
     "wof:belongsto":[
         85632371,
         136253037,
-        102191575,
-        1158846601
+        102191575
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -404,8 +403,9 @@
         "wd:id":"Q570289",
         "wk:page":"Miquelon-Langlade"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PM",
-    "wof:geomhash":"fee4aba5aa96cec404f9bdc8bee53363",
+    "wof:geomhash":"1e439604017e38cc52629f0cb4eb8d49",
     "wof:hierarchy":[
         {
             "continent":102191575,
@@ -423,7 +423,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690855721,
+    "wof:lastmodified":1695884938,
     "wof:name":"Miquelon-Langlade",
     "wof:parent_id":1158846601,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.